### PR TITLE
feat: resets genserver inactivity with :keep_alive info message

### DIFF
--- a/lib/ash_gen_server/server.ex
+++ b/lib/ash_gen_server/server.ex
@@ -122,6 +122,10 @@ defmodule AshGenServer.Server do
     end
   end
 
+  def handle_info(:keep_alive, state) do
+    {:noreply, maybe_set_inactivity_timer(state)}
+  end
+
   defp primary_key_from_resource_and_changeset(resource, changeset) do
     resource
     |> Resource.Info.primary_key()

--- a/test/ash_gen_server/server_test.exs
+++ b/test/ash_gen_server/server_test.exs
@@ -38,4 +38,17 @@ defmodule AshGenServer.ServerTest do
       refute state.record.nickname
     end
   end
+
+  describe "handle_info/3" do
+    test "when send :keep_alive to server resets inactivity timer" do
+      changeset =
+        TimeTravel.Character
+        |> Changeset.for_create(:create, %{name: "Biff Tannen", current_year: 2015})
+
+      {:ok, old_state} = Server.init([TimeTravel.Character, changeset])
+      {:noreply, new_state} = Server.handle_info(:keep_alive, old_state)
+
+      refute old_state.inactivity_timer == new_state.inactivity_timer
+    end
+  end
 end

--- a/test/support/time_travel/character.ex
+++ b/test/support/time_travel/character.ex
@@ -37,4 +37,8 @@ defmodule TimeTravel.Character do
     create_timestamp(:created_at)
     update_timestamp(:updated_at)
   end
+
+  gen_server do
+    inactivity_timeout(:timer.minutes(1))
+  end
 end


### PR DESCRIPTION
You can now reset `ash_gen_server` inactivity timer by sending it a `:keep_alive` message.